### PR TITLE
Classroom Select Screen, other minor changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-dom": "^16.13.1",
     "react-native": "^0.61.5",
     "react-native-calendars": "^1.1209.0",
+    "react-native-drawer": "^2.5.1",
     "react-native-elements": "^1.2.7",
     "react-native-formik": "^1.7.8",
     "react-native-gesture-handler": "^1.5.6",
@@ -35,7 +36,7 @@
     "react-native-vector-icons": "^6.7.0",
     "react-native-video": "^4.4.5",
     "react-native-video-controls": "^2.6.0",
-    "react-navigation": "^4.4.0",
+    "react-navigation": "^4.4.3",
     "react-navigation-stack": "^2.8.2"
   },
   "devDependencies": {

--- a/src/components/const.js
+++ b/src/components/const.js
@@ -9,14 +9,6 @@ const roles = {
   default: 'STUDENT',
 };
 
-const terms = {
-  fall: 'FALL',
-  winter: 'WINTER',
-  spring: 'SPRING',
-  summer: 'SUMMER',
-  default: 'FALL',
-};
-
 const classTypes = {
   group: 'group',
   ensemble: 'ensemble',
@@ -53,12 +45,10 @@ const INITIAL_CLASSROOM_STATE = {
   studentIDs: [],
   name: '',
   type: classTypes.default,
-  term: [],
-  year: 2021,
   meetDays: [],
   classLength: 0,
-  startDate: '',
-  endDate: '',
+  startDate: '', // 'yyyy-mm-dd'
+  endDate: '', // 'yyyy-mm-dd'
   description: '',
   createdAt: '',
 };
@@ -78,7 +68,7 @@ const INITIAL_CHAT_STATE = {
 //////////////////////////////////////////////////////
 
 export {
-  roles, terms, classTypes, classDays,
+  roles, classTypes, classDays,
 };
 export {
   INITIAL_USER_STATE, INITIAL_CLASSROOM_STATE, INITIAL_MESSAGE_STATE, INITIAL_CHAT_STATE,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -4,7 +4,6 @@ import {
   INITIAL_MESSAGE_STATE,
   INITIAL_CHAT_STATE,
   roles,
-  terms,
   classDays,
   classTypes,
 } from './const';
@@ -15,7 +14,6 @@ export {
   INITIAL_MESSAGE_STATE,
   INITIAL_CHAT_STATE,
   roles,
-  terms,
   classDays,
   classTypes,
 };

--- a/src/navigation/AppNavigation.js
+++ b/src/navigation/AppNavigation.js
@@ -11,6 +11,7 @@ import GenericFormDemoScreen from '../screens/GenericFormDemo';
 import AnnouncementsScreen from '../screens/Announcements';
 import AssignmentListScreen from '../screens/AssignmentList';
 import { ClassroomHome, CreateClassroomScreen } from '../screens/Classroom';
+import ClassroomSelectScreen from '../screens/Landing';
 
 const AppNavigation = createStackNavigator(
   {
@@ -29,9 +30,10 @@ const AppNavigation = createStackNavigator(
     AssignmentList: AssignmentListScreen,
     CreateClassroom: CreateClassroomScreen,
     Classroom: ClassroomHome,
+    Landing: ClassroomSelectScreen,
   },
   {
-    initialRouteName: 'Home',
+    initialRouteName: 'Landing',
   },
 );
 

--- a/src/screens/Classroom/ClassroomHome.js
+++ b/src/screens/Classroom/ClassroomHome.js
@@ -14,6 +14,7 @@ import { INITIAL_USER_STATE } from '../../components';
 const styles = StyleSheet.create({
 
   headingTitle: {
+    textAlign: 'center',
     fontSize: 28,
     fontWeight: '600',
   },
@@ -34,6 +35,10 @@ const styles = StyleSheet.create({
   highlight: {
     fontWeight: '700',
   },
+  subContainerButton: {
+    marginBottom: 15,
+    padding: 5,
+  },
 });
 
 // navigation MUST INCLUDE: code, classroomInfo, uid
@@ -44,6 +49,7 @@ export default function ClassroomHome({ navigation }) {
   const [userState, setUserState] = useState(INITIAL_USER_STATE);
 
   useEffect(() => {
+    let mounted = true;
     // fetch user data
     Firestore().collection('users')
       .doc(uid)
@@ -55,11 +61,13 @@ export default function ClassroomHome({ navigation }) {
         return null;
       })
       .then((data) => {
-        setUserState(data);
+        if (mounted) { setUserState(data); }
       })
       .catch((e) => {
         Alert.alert(e.message);
       });
+
+    return () => { mounted = false; };
   });
 
   // copies code to clipboard
@@ -89,12 +97,6 @@ export default function ClassroomHome({ navigation }) {
             {`Type: ${classroomInfo.type}`}
           </Text>
           <Text style={styles.sectionDescription}>
-            {`Terms: ${classroomInfo.term}`}
-          </Text>
-          <Text style={styles.sectionDescription}>
-            {`Year: ${classroomInfo.year}`}
-          </Text>
-          <Text style={styles.sectionDescription}>
             {`Meet Days: ${classroomInfo.meetDays}`}
           </Text>
           <Text style={styles.sectionDescription}>
@@ -109,6 +111,15 @@ export default function ClassroomHome({ navigation }) {
           {/*
           <Button title="Make a Post!" onPress={() => navigation.navigate('Make a New Post')} />
           */}
+          <View style={styles.subContainerButton}>
+            <Button
+              style={styles.textInput}
+              title="Back to Landing"
+              onPress={() => {
+                navigation.navigate('Landing', uid);
+              }}
+            />
+          </View>
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/src/screens/Classroom/CreateClassroomScreen.js
+++ b/src/screens/Classroom/CreateClassroomScreen.js
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
 import Firestore from '@react-native-firebase/firestore';
 import { TouchableHighlight } from 'react-native-gesture-handler';
 import {
-  INITIAL_CLASSROOM_STATE, classTypes, terms, classDays,
+  INITIAL_CLASSROOM_STATE, classTypes, classDays,
 } from '../../components';
 // import Post from './Post';
 
@@ -54,12 +54,6 @@ export default function CreateClassroomScreen({ navigation }) {
   const [className, setName] = useState(''); // state var to hold class name
   const [classDesc, setDesc] = useState(''); // state var to hold class description
   const [classType, setType] = useState(classTypes.default); // state var to hold class type
-  const [termToggle, setTerm] = useState({
-    fall: false,
-    spring: false,
-    summer: false,
-    winter: false,
-  }); // state var keeping track of term checkboxes
   const [dayToggle, setDays] = useState({
     mon: false,
     tues: false,
@@ -106,9 +100,6 @@ export default function CreateClassroomScreen({ navigation }) {
     if (className.length === 0) {
       // class name empty
       Alert.alert('Please input a class name.');
-    } else if (!termToggle.fall && !termToggle.winter && !termToggle.spring && !termToggle.summer) {
-      // terms empty
-      Alert.alert('Please select a term(s).');
     } else if (!dayToggle.mon && !dayToggle.tues && !dayToggle.wed
             && !dayToggle.thurs && !dayToggle.fri) {
       // meet days empty
@@ -127,12 +118,6 @@ export default function CreateClassroomScreen({ navigation }) {
       Alert.alert('Please make sure the end date is after the start date.');
     } else {
       const code = await makeid(6); // generate unique code
-      const classTerms = [];
-      // 4 if statements instead of forEach to ensure proper ordering
-      if (termToggle.fall) classTerms.push(terms.fall);
-      if (termToggle.winter) classTerms.push(terms.winter);
-      if (termToggle.spring) classTerms.push(terms.spring);
-      if (termToggle.summer) classTerms.push(terms.summer);
 
       const days = [];
       // 5 if statements instead of forEach to ensure proper ordering
@@ -148,7 +133,6 @@ export default function CreateClassroomScreen({ navigation }) {
         teacherIDs: [uid],
         name: className,
         type: classType,
-        term: classTerms,
         meetDays: days,
         startDate: classStart,
         endDate: classEnd,
@@ -207,73 +191,6 @@ export default function CreateClassroomScreen({ navigation }) {
             <Picker.Item label="Mentorship" value={classTypes.mentorship} />
             <Picker.Item label="Private Lessons" value={classTypes.private_lessons} />
           </Picker>
-        </View>
-        <View style={styles.subContainer}>
-          <Text>Terms:</Text>
-          <View style={styles.checklist}>
-            <CheckBox
-              value={termToggle.fall}
-              onValueChange={(value) => {
-                setTerm({ ...termToggle, fall: value });
-              }}
-            />
-            <TouchableHighlight
-              onPress={() => {
-                setTerm({ ...termToggle, fall: !termToggle.fall });
-              }}
-              underlayColor="#E1E1E1"
-            >
-              <Text>FALL</Text>
-            </TouchableHighlight>
-          </View>
-          <View style={styles.checklist}>
-            <CheckBox
-              value={termToggle.winter}
-              onValueChange={(value) => {
-                setTerm({ ...termToggle, winter: value });
-              }}
-            />
-            <TouchableHighlight
-              onPress={() => {
-                setTerm({ ...termToggle, winter: !termToggle.winter });
-              }}
-              underlayColor="#E1E1E1"
-            >
-              <Text>WINTER</Text>
-            </TouchableHighlight>
-          </View>
-          <View style={styles.checklist}>
-            <CheckBox
-              value={termToggle.spring}
-              onValueChange={(value) => {
-                setTerm({ ...termToggle, spring: value });
-              }}
-            />
-            <TouchableHighlight
-              onPress={() => {
-                setTerm({ ...termToggle, spring: !termToggle.spring });
-              }}
-              underlayColor="#E1E1E1"
-            >
-              <Text>SPRING</Text>
-            </TouchableHighlight>
-          </View>
-          <View style={styles.checklist}>
-            <CheckBox
-              value={termToggle.summer}
-              onValueChange={(value) => {
-                setTerm({ ...termToggle, summer: value });
-              }}
-            />
-            <TouchableHighlight
-              onPress={() => {
-                setTerm({ ...termToggle, summer: !termToggle.summer });
-              }}
-              underlayColor="#E1E1E1"
-            >
-              <Text>SUMMER</Text>
-            </TouchableHighlight>
-          </View>
         </View>
         <View style={styles.subContainer}>
           <Text>Meet days:</Text>

--- a/src/screens/Landing/ClassSelections.js
+++ b/src/screens/Landing/ClassSelections.js
@@ -1,0 +1,198 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useState, useEffect } from 'react';
+import {
+  View, StyleSheet, Button, Alert,
+} from 'react-native';
+import { Text } from 'react-native-elements';
+import PropTypes from 'prop-types';
+import Firestore from '@react-native-firebase/firestore';
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 10,
+    marginBottom: 10,
+    marginHorizontal: 10,
+    padding: 10,
+    backgroundColor: '#ffffff',
+    borderRadius: 10,
+  },
+  subContainer: {
+    marginBottom: 10,
+    padding: 10,
+  },
+  topicText: {
+    textAlign: 'center',
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  textInput: {
+    fontSize: 18,
+    margin: 5,
+    width: 200,
+  },
+});
+
+export default function ClassSelections({
+  classroomData, uid, userState, navigation,
+}) {
+  const [past, setPast] = useState([]);
+  const [currClasses, setCurr] = useState([]);
+  const [showPast, setShow] = useState(false);
+
+  const date = new Date();
+  let currDate = '';
+  currDate += `${date.getFullYear()}-`;
+  if (date.getMonth() < 9) {
+    currDate += `0${date.getMonth() + 1}-`;
+  } else {
+    currDate += `${date.getMonth() + 1}-`;
+  }
+  if (date.getDate() <= 9) {
+    currDate += `0${date.getDate()}`;
+  } else {
+    currDate += `${date.getDate()}`;
+  }
+
+  useEffect(() => {
+    classroomData.forEach((c) => {
+      const classroomInfo = c;
+      const classCode = c.code;
+      delete classroomInfo.code;
+      if (userState.role === 'TEACHER') {
+        if (c.endDate > currDate) {
+          setCurr((cl) => [...cl, { info: classroomInfo, code: classCode }]);
+        } else {
+          setPast((cl) => [...cl, { info: classroomInfo, code: classCode }]);
+        }
+      } else if (userState.role === 'STUDENT') {
+        const teacherNames = [];
+        c.teacherIDs.forEach((t) => {
+          Firestore().collection('users').doc(t).get()
+            .then((teacher) => {
+              teacherNames.push(teacher.data().name);
+            })
+            .catch((e) => {
+              Alert.alert(e.message);
+            });
+        });
+        if (c.endDate > currDate) {
+          setCurr((cl) => [...cl, { info: classroomInfo, code: classCode, teacherNames }]);
+        } else {
+          setPast((cl) => [...cl, { info: classroomInfo, code: classCode, teacherNames }]);
+        }
+      }
+    });
+  }, []);
+
+  return (
+    <View>
+      <View style={styles.container}>
+        <Text>
+          ACTIVE CLASSES
+        </Text>
+        {currClasses.map((c) => (
+          <View style={styles.subContainer} key={c.code}>
+            <View style={styles.subContainer}>
+              <Text style={styles.topicText}>
+                {`Class Name: ${c.info.name}`}
+              </Text>
+            </View>
+            {userState.role === 'TEACHER' && (
+            <View style={styles.subContainer}>
+              <Text style={styles.topicText}>
+                {`Number of Students: ${c.info.studentIDs.length}`}
+              </Text>
+            </View>
+            )}
+            {userState.role === 'STUDENT' && (
+            <View style={styles.subContainer}>
+              <Text style={styles.topicText}>
+                Teachers:
+              </Text>
+              {c.teacherNames.map((n) => (
+                <Text style={styles.topicText} key={n}>
+                  {n}
+                </Text>
+              ))}
+            </View>
+            )}
+            <Button
+              style={styles.textInput}
+              title="OPEN"
+              onPress={() => {
+                navigation.navigate('Classroom', { code: c.code, classroomInfo: c.info, uid });
+              }}
+            />
+          </View>
+        ))}
+      </View>
+      <View style={styles.container}>
+        {!showPast
+          ? (
+            <Button
+              style={styles.textInput}
+              title="OPEN PAST CLASSES"
+              onPress={() => {
+                setShow(true);
+              }}
+            />
+          ) : (
+            <Button
+              style={styles.textInput}
+              title="CLOSE PAST CLASSES"
+              onPress={() => {
+                setShow(false);
+              }}
+            />
+          )}
+        {showPast && past.map((c) => (
+          <View style={styles.subContainer} key={c.code}>
+            <View style={styles.subContainer}>
+              <Text style={styles.topicText}>
+                {`Class Name: ${c.info.name}`}
+              </Text>
+            </View>
+            {userState.role === 'TEACHER' && (
+            <View style={styles.subContainer}>
+              <Text style={styles.topicText}>
+                {`Number of Students: ${c.info.studentIDs.length}`}
+              </Text>
+            </View>
+            )}
+            {userState.role === 'STUDENT' && (
+            <View style={styles.subContainer}>
+              <Text style={styles.topicText}>
+                Teachers:
+              </Text>
+              {c.teacherNames.map((n) => (
+                <Text style={styles.topicText} key={n}>
+                  {n}
+                </Text>
+              ))}
+            </View>
+            )}
+            <Button
+              style={styles.textInput}
+              title="OPEN"
+              onPress={() => {
+                navigation.navigate('Classroom', { code: c.code, classroomInfo: c.info, uid });
+              }}
+            />
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+ClassSelections.propTypes = {
+  // eslint-disable-next-line react/forbid-prop-types
+  classroomData: PropTypes.array.isRequired,
+  uid: PropTypes.string.isRequired,
+  // eslint-disable-next-line react/forbid-prop-types
+  userState: PropTypes.object.isRequired,
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func.isRequired,
+    getParam: PropTypes.func.isRequired,
+  }).isRequired,
+};

--- a/src/screens/Landing/ClassroomSelectScreen.js
+++ b/src/screens/Landing/ClassroomSelectScreen.js
@@ -169,7 +169,7 @@ export default function ClassroomSelectScreen({ navigation }) {
   }, [user]);
 
   useEffect(() => {
-    const focusListener = navigation.addListener('didFocus', () => {
+    function fetch() {
       setLoading(true);
       setClasses([]);
       // if the user is signed in, then fetch its data and fetch classrooms
@@ -219,6 +219,11 @@ export default function ClassroomSelectScreen({ navigation }) {
           navigation.navigate('CreateClassroom', { uid });
         } */
       }
+    }
+    fetch();
+
+    const focusListener = navigation.addListener('didFocus', () => {
+      fetch();
     });
 
     return () => focusListener.remove();

--- a/src/screens/Landing/ClassroomSelectScreen.js
+++ b/src/screens/Landing/ClassroomSelectScreen.js
@@ -1,0 +1,406 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useState, useEffect } from 'react';
+import {
+  SafeAreaView, ScrollView, StyleSheet, Platform, View, Alert, TextInput,
+} from 'react-native';
+import { Button, Text, Icon } from 'react-native-elements';
+import Drawer from 'react-native-drawer';
+import Firestore from '@react-native-firebase/firestore';
+import Auth from '@react-native-firebase/auth';
+import PropTypes from 'prop-types';
+import { INITIAL_USER_STATE } from '../../components';
+import ClassSelections from './ClassSelections';
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 10,
+    marginBottom: 10,
+    marginHorizontal: 10,
+    padding: 10,
+    backgroundColor: '#ffffff',
+    borderRadius: 10,
+  },
+  sideMenu: {
+    height: '100%',
+    backgroundColor: '#ffffff',
+  },
+  header: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignSelf: 'flex-start',
+    alignItems: 'center',
+    width: '100%',
+    height: 56,
+    backgroundColor: '#ffffff',
+    borderBottomColor: 'rgb(216, 216, 216)',
+    shadowColor: 'rgb(216, 216, 216)',
+    ...Platform.select({
+      android: {
+        elevation: 4,
+      },
+      ios: {
+        shadowOpacity: 0.85,
+        shadowRadius: 0,
+        shadowOffset: {
+          width: 0,
+          height: StyleSheet.hairlineWidth,
+        },
+      },
+      default: {
+        borderBottomWidth: StyleSheet.hairlineWidth,
+      },
+    }),
+  },
+  headerLeft: {
+    marginLeft: 10,
+    flex: 1,
+    display: 'flex',
+    alignItems: 'flex-start',
+  },
+  headerRight: {
+    flex: 1,
+    display: 'flex',
+    justifyContent: 'flex-end',
+  },
+  button: {
+    width: 20,
+  },
+  headerText: {
+    marginLeft: 65,
+    marginRight: 75,
+  },
+  headerTextText: {
+    ...Platform.select({
+      ios: {
+        fontSize: 17,
+        fontWeight: '600',
+      },
+      android: {
+        fontSize: 20,
+        fontFamily: 'sans-serif-medium',
+        fontWeight: 'normal',
+      },
+      default: {
+        fontSize: 18,
+        fontWeight: '500',
+      },
+    }),
+  },
+  subContainer: {
+    marginBottom: 10,
+    padding: 10,
+  },
+  textInput: {
+    fontSize: 18,
+    margin: 5,
+    width: 200,
+  },
+  contentContainer: {
+    paddingTop: 20,
+  },
+  topicText: {
+    textAlign: 'center',
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  scroll: {
+    height: '88%',
+    marginBottom: 10,
+  },
+});
+
+const drawerStyles = StyleSheet.create({
+  drawer: { shadowColor: '#000000', shadowOpacity: 0.8, shadowRadius: 3 },
+  main: { paddingLeft: 3 },
+});
+
+// navigation MUST INCLUDE: uid
+export default function ClassroomSelectScreen({ navigation }) {
+  const [initializing, setInitializing] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [user, setUser] = useState();
+  const [userState, setUserState] = useState(INITIAL_USER_STATE);
+  const [uid, setUid] = useState(navigation.getParam('uid', null));
+  const [code, setCode] = useState('');
+  const [toggleMenu, setToggle] = useState(false); // toggle drawer
+
+  const [classrooms, setClasses] = useState([]);
+
+  // input code, join
+  async function joinClassroom() {
+    const classRef = Firestore().collection('classrooms');
+    const doc = await classRef.doc(code.toLowerCase()).get();
+    const classroomInfo = doc.data();
+    if (!classroomInfo) {
+      Alert.alert(
+        'Please input a valid code!',
+      );
+    } else {
+      // if user is a student or teacher, add their id to the classroom
+      if (userState.role === 'STUDENT') {
+        classRef.doc(code.toLowerCase()).update({
+          studentIDs: Firestore.FieldValue.arrayUnion(user.uid),
+        });
+      }
+      if (userState.role === 'TEACHER') {
+        classRef.doc(code.toLowerCase()).update({
+          teacherIDs: Firestore.FieldValue.arrayUnion(user.uid),
+        });
+      }
+      setToggle(false);
+      navigation.navigate('Classroom', { code, classroomInfo, uid });
+    }
+  }
+
+  function onAuthStateChanged(authUser) {
+    setUser(authUser);
+    if (initializing) setInitializing(false);
+  }
+
+  // check signin on mount
+  useEffect(() => {
+    const subscriber = Auth().onAuthStateChanged(onAuthStateChanged);
+    return subscriber; // unsubscribe on unmount
+  }, []);
+
+  // if signed in, set uid
+  useEffect(() => {
+    if (user && !uid) setUid(user.uid);
+  }, [user]);
+
+  useEffect(() => {
+    const focusListener = navigation.addListener('didFocus', () => {
+      setLoading(true);
+      setClasses([]);
+      // if the user is signed in, then fetch its data and fetch classrooms
+      if (uid) {
+        Firestore().collection('users')
+          .doc(uid)
+          .get()
+          .then((document) => {
+            if (document.exists) {
+              return document.data();
+            }
+            return null;
+          })
+          .then(async (data) => {
+            setUserState(data);
+            await Firestore().collection('classrooms').orderBy('endDate', 'desc').get()
+              .then((querySnapshot) => {
+                querySnapshot.forEach((doc) => {
+                  if (data.role === 'TEACHER') {
+                    if (doc.id.length === 6) {
+                      doc.data().teacherIDs.forEach((element) => {
+                        if (element === uid) {
+                          setClasses((c) => [...c, { ...doc.data(), code: doc.id }]);
+                        }
+                      });
+                    }
+                  } else if (data.role === 'STUDENT') {
+                    if (doc.id.length === 6) {
+                      doc.data().studentIDs.forEach((element) => {
+                        if (element === uid) {
+                          setClasses((c) => [...c, { ...doc.data(), code: doc.id }]);
+                        }
+                      });
+                    }
+                  }
+                });
+              });
+
+            if (loading) setLoading(false);
+          })
+          .catch((e) => {
+            Alert.alert(e.message);
+          });
+        // force teacher to create classroom on login
+        /* if (userState && userState.role && userState.role === 'TEACHER'
+        && userState.classroomIds.length === 0) {
+          navigation.navigate('CreateClassroom', { uid });
+        } */
+      }
+    });
+
+    return () => focusListener.remove();
+  }, [uid]);
+
+  // if signing in, return null
+  if (initializing) return null;
+
+  // if not logged in, unmount and go to signin page
+  if (!user) {
+    return navigation.navigate('SignIn');
+  }
+
+  // if loading user data, return the base views
+  if (loading) {
+    return (
+      <SafeAreaView>
+        <View style={styles.header}>
+          <View style={styles.headerLeft}>
+            <Icon
+              name="menu"
+              size={36}
+              color="#000000"
+            />
+          </View>
+          <View style={styles.headerText}>
+            <Text style={styles.headerTextText}>
+              Home
+            </Text>
+          </View>
+          <View style={styles.headerRight}>
+            <Button
+              title="Sign Out"
+              buttonStyle={{ padding: 5, marginRight: 20 }}
+              style={styles.button}
+            />
+          </View>
+        </View>
+        <Text style={styles.topicText}>
+          {`Welcome ${user.email}!`}
+        </Text>
+        <Text style={styles.topicText}>
+          LOADING...
+        </Text>
+      </SafeAreaView>
+    );
+  }
+
+  const menu = (
+    <View style={styles.sideMenu}>
+      <View style={styles.subContainer}>
+        <Button
+          style={styles.textInput}
+          title="Profile"
+          onPress={() => {
+            setToggle(false);
+            navigation.navigate('Profile', { uid });
+          }}
+        />
+      </View>
+      <View style={styles.subContainer}>
+        <TextInput
+          placeholder="ABCDEF"
+          fontSize={20}
+          maxLength={6}
+          onChangeText={setCode}
+          value={code}
+        />
+        <Button
+          style={styles.textInput}
+          title="Join"
+          onPress={() => {
+            setToggle(false);
+            joinClassroom();
+          }}
+        />
+      </View>
+      {userState && userState.role === 'TEACHER'
+    && (
+    <View style={styles.subContainer}>
+      <Button
+        style={styles.textInput}
+        title="Create Classroom"
+        onPress={() => {
+          setToggle(false);
+          navigation.navigate('CreateClassroom', { uid });
+          // for now a separate page using this button
+        }}
+      />
+    </View>
+    )}
+      <View style={styles.subContainer}>
+        <Button
+          style={styles.textInput}
+          title="Settings"
+          onPress={() => {
+          }}
+        />
+      </View>
+    </View>
+  );
+
+  return (
+    <Drawer
+      type="overlay"
+      content={menu}
+      tapToClose
+      open={toggleMenu}
+      onClose={() => { setToggle(false); }}
+      openDrawerOffset={0.2} // 20% gap on the right side of drawer
+      panCloseMask={0.2}
+      closedDrawerOffset={-3}
+      styles={drawerStyles}
+      tweenHandler={(ratio) => ({
+        main: { opacity: (2 - ratio) / 2 },
+      })}
+    >
+      <SafeAreaView>
+        <View style={styles.header}>
+          <View style={styles.headerLeft}>
+            <Icon
+              name="menu"
+              size={36}
+              color="#000000"
+              onPress={() => { setToggle(!toggleMenu); }}
+            />
+          </View>
+          <View style={styles.headerText}>
+            <Text style={styles.headerTextText}>
+              Home
+            </Text>
+          </View>
+          <View style={styles.headerRight}>
+            <Button
+              title="Sign Out"
+              buttonStyle={{ padding: 5, marginRight: 20 }}
+              onPress={() => { Auth().signOut(); }}
+              style={styles.button}
+            />
+          </View>
+        </View>
+        <Text style={styles.topicText}>
+          {`Welcome ${userState.email}!`}
+        </Text>
+        <ScrollView style={styles.scroll}>
+          <ClassSelections
+            classroomData={classrooms}
+            uid={uid}
+            userState={userState}
+            navigation={navigation}
+          />
+        </ScrollView>
+      </SafeAreaView>
+    </Drawer>
+
+  );
+}
+
+ClassroomSelectScreen.navigationOptions = {
+  headerShown: false,
+  title: 'Landing',
+  /* headerLeft: () => (
+    <Icon
+      name="menu"
+      size={36}
+      color="#000000"
+      onPress={() => { }}
+    />
+  ),
+  headerRight: () => (
+    <Button
+      title="Sign Out"
+      buttonStyle={{ padding: 5, marginRight: 20 }}
+      onPress={() => { Auth().signOut(); }}
+    />
+  ), */
+};
+
+ClassroomSelectScreen.propTypes = {
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func.isRequired,
+    getParam: PropTypes.func.isRequired,
+    addListener: PropTypes.func.isRequired,
+  }).isRequired,
+};

--- a/src/screens/Landing/index.js
+++ b/src/screens/Landing/index.js
@@ -1,0 +1,3 @@
+import ClassroomSelectScreen from './ClassroomSelectScreen';
+
+export default ClassroomSelectScreen;

--- a/src/screens/Profile/ProfileScreen.js
+++ b/src/screens/Profile/ProfileScreen.js
@@ -179,6 +179,15 @@ export default function ProfileScreen({ navigation }) {
             }}
           />
         </View>
+        <View style={styles.subContainerButton}>
+          <Button
+            style={styles.textInput}
+            title="Back to Landing"
+            onPress={() => {
+              navigation.navigate('Landing');
+            }}
+          />
+        </View>
       </View>
     </View>
   );

--- a/src/screens/SignIn/SignInScreen.js
+++ b/src/screens/SignIn/SignInScreen.js
@@ -47,9 +47,9 @@ export default function SignInScreen({ navigation }) {
     try {
       const doSignIn = await Auth().signInWithEmailAndPassword(email, password);
       setShowLoading(false);
-      // if valid signin, navigate to home
+      // if valid signin, navigate to landing
       if (doSignIn.user) {
-        navigation.navigate('Home', { uid: doSignIn.user.uid });
+        navigation.navigate('Landing', { uid: doSignIn.user.uid });
       }
     } catch (e) {
       setShowLoading(false);

--- a/src/screens/SignUp/SignUpScreen.js
+++ b/src/screens/SignUp/SignUpScreen.js
@@ -65,8 +65,8 @@ export default function SignUpScreen({ navigation }) {
         const { user } = doSignUp;
         setShowLoading(false);
         if (user) {
-          // check if classroom exists before signing up student/parent
-          if (userState.role === 'PARENT' || userState.role === 'STUDENT') {
+          // check if classroom exists before signing up student
+          if (userState.role === 'STUDENT') {
             classRef.doc(code.toLowerCase()).get()
               .then((document) => {
                 if (document.exists) {
@@ -79,7 +79,7 @@ export default function SignUpScreen({ navigation }) {
                   // if user is a student, add their id to the classroom
                   if (userState.role === 'STUDENT') {
                     classRef.doc(code.toLowerCase()).update({
-                      students: Firestore.FieldValue.arrayUnion(user.uid),
+                      studentIDs: Firestore.FieldValue.arrayUnion(user.uid),
                     });
                   }
                   Firestore().collection('users').doc(user.uid).set({
@@ -106,7 +106,7 @@ export default function SignUpScreen({ navigation }) {
               updatedAt: Firestore.FieldValue.serverTimestamp(),
             });
             // sign in and navigate to home screen upon signup
-            navigation.navigate('Home', { uid: user.uid });
+            navigation.navigate('Landing', { uid: user.uid });
           }
         }
       } catch (e) {
@@ -146,7 +146,6 @@ export default function SignUpScreen({ navigation }) {
             }}
           >
             <Picker.Item label="Student" value={roles.student} />
-            <Picker.Item label="Parent" value={roles.parent} />
             <Picker.Item label="Teacher" value={roles.teacher} />
           </Picker>
         </View>
@@ -172,8 +171,8 @@ export default function SignUpScreen({ navigation }) {
             onChangeText={setPassword}
           />
         </View>
-        {(userState.role === 'PARENT' || userState.role === 'STUDENT')
-        // show join code textinput only when user is signing up as a student or parent
+        {userState.role === 'STUDENT'
+        // show join code textinput only when user is signing up as a student
         && (
           <View style={styles.subContainer}>
             <Text style={{ fontSize: 20, height: 40 }}>Classroom code:</Text>


### PR DESCRIPTION
## Classroom Selection Screen

### General
- Default home page now set to "Landing," which is **ClassroomSelectScreen.js**
- **ClassroomSelectScreen** passes props (`classroomData`) to **ClassSelections.js** so it can display active classes and past classes.

### ClassroomSelectScreen
- Page displays "LOADING..." on focus so it can refresh if necessary when a classroom is created or joined. This currently happens on any focus, however (a state variable could be employed so that this only occur when created/joined, but I'm not sure how huge of an issue this would be). See _first_ screenshot below.
  - This works via `focusListener`, a listener that checks when the screen `didFocus` or not.
  -  On mount, `focusListener` is not called so `fetch()` is called by `useEffect`
  - Every subsequent focus, it fetches user data via `fetch()` to set `userState` and then asynchronously fetches class data (saved in `classrooms`, passed to **ClassSelections** as the `classroomData` prop).
  - It then sets `loading` to false, allowing the full page to display
- Upon load, you can see active classes and a button to toggle past classes. This portion of the screen is created from a `ClassSelections` component. `ClassSelections` is part of a `ScrollView`, so it is scrollable. See _second - fourth_ screenshot below.
- `Drawer` menu's contents are held in `const menu`  - containing Profile, Join Classroom, and Create Classroom like before. Settings doesn't route anywhere at the moment. See _fifth_ screenshot below.

<img src="https://user-images.githubusercontent.com/69874869/109438624-a9e5a700-79df-11eb-8c65-4ba393b546df.png"  width="160" /><img src="https://user-images.githubusercontent.com/69874869/109438625-aa7e3d80-79df-11eb-9598-4b57b2dd01fc.png"  width="160" /><img src="https://user-images.githubusercontent.com/69874869/109438626-aa7e3d80-79df-11eb-8d39-63685fe205dc.png"  width="160" /><img src="https://user-images.githubusercontent.com/69874869/109438627-ab16d400-79df-11eb-82c2-caf836004770.png"  width="160" /><img src="https://user-images.githubusercontent.com/69874869/109438628-ab16d400-79df-11eb-86aa-fda7e0bc8ad0.png"  width="160" />

### ClassSelections
- Upon receiving the `classroomData` prop, it parses through Firestore via promise chains to split classes based on whether the `endDate` for a classroom is before (stored in `past`) or after the current date (stored in `currClasses`). Also adds the `teacherNames` field for Students so the classes will display the teacher. See screenshot below.
  - classes are sorted via Firebase's `orderBy()` function
- Toggles past classes via `pastToggle` state variable

<img src="https://user-images.githubusercontent.com/69874869/109439232-5c1e6e00-79e2-11eb-8adb-6ca5a960e9b8.png"  width="200" />


### Miscellaneous
- Changed things throughout (**index**, **const**, **CreateClassroomScreen**, **ClassroomHome**) to match w/ schema
- installed `react-native-drawer` for the drawer menu
  - potentially could use React Navigation's drawer (https://reactnavigation.org/docs/drawer-based-navigation/) in the future, due to to-be deprecated features in `react-native-drawer`
- removed parent functionality throughout