### PR TITLE
Feedback Loading and Time Display Fix

### DIFF
--- a/src/screens/Feedback/Feedback.js
+++ b/src/screens/Feedback/Feedback.js
@@ -27,7 +27,7 @@ export default function FeedbackPost({
   // Gets a time value and outputs the appropripate minutes:seconds text
   function getTime(unprocessedTime) {
     const minutes = unprocessedTime >= 60 ? Math.floor(unprocessedTime / 60) : 0;
-    const seconds = Math.floor(unprocessedTime - minutes * 60);
+    const seconds = Math.round(unprocessedTime - minutes * 60);
 
     return `${minutes >= 10 ? minutes : `0${minutes}`}:${
       seconds >= 10 ? seconds : `0${seconds}`

--- a/src/screens/Feedback/FeedbackScreen.js
+++ b/src/screens/Feedback/FeedbackScreen.js
@@ -80,7 +80,7 @@ function CreateFeedback({
 
   /* If the user moves the slider, then UsedSlider will be set to true
   in order to remove the helper message. The floor function is used to
-  account for the delay between the acctual current time and the saved
+  account for the delay between the actual current time and the saved
   initial time. Basically, currentTime could be 5.003 seconds but the
   saved initialTime could be 5.002 seconds. Basically the same but code
   sees it as different.
@@ -258,14 +258,25 @@ export default function FeedbackScreen({ route }) {
             />
           )));
         }
+      })
+      .then(() => {
+        /* Firebase is weird and we need to load it an extra time. This
+        could simply be due to the server's latency.
+        */
+        if (loadCounter < 1 && !loadingVideo) {
+          setLoadCounter(loadCounter + 1);
+        }
       });
 
-    // Firebase is weird and we need to reload a few times
-    if (loadCounter < 3 && !loadingVideo) {
-      setLoadCounter(loadCounter + 1);
-    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [addFeedback, submissionID, loadCounter, loadingVideo]);
+
+  /* Resets loadcounter everytime feedback is added. This will allow the
+  new feedback (if it's made) to be rendered on the feedback screen.
+  */
+  useEffect(() => {
+    setLoadCounter(0);
+  }, [addFeedback]);
 
   return (
     <ScrollView>

--- a/src/screens/Feedback/FeedbackScreen.js
+++ b/src/screens/Feedback/FeedbackScreen.js
@@ -93,7 +93,7 @@ function CreateFeedback({
   // Gets a time value and outputs the appropripate minutes:seconds text
   function getTime(time) {
     const minutes = time >= 60 ? Math.floor(time / 60) : 0;
-    const seconds = Math.floor(time - minutes * 60);
+    const seconds = Math.round(time - minutes * 60);
 
     return `${minutes >= 10 ? minutes : `0${minutes}`}:${
       seconds >= 10 ? seconds : `0${seconds}`


### PR DESCRIPTION
Upon loading the feedback screen, all the associated feedback posts should load without needing to refresh the page or reloading the emulator. Once a new feedback post is made, it should also be displayed without needing to refresh the page or reloading the emulator. In theory.

Also fixed rounding errors when displaying time pin. For example, sometimes it would show 0:07 on the feedback post but jump to 0:08. This was due to using the floor function when calculating seconds but it should have be the round function. oops. 